### PR TITLE
refactor: check the commit message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,6 +616,9 @@ name = "strum"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7ac893c7d471c8a21f31cfe213ec4f6d9afeed25537c772e08ef3f005f8729e"
+dependencies = [
+ "strum_macros 0.22.0",
+]
 
 [[package]]
 name = "strum_macros"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ thiserror = "1.0"
 avro-rs = "0.13"
 structopt = { version = "0.3", features = [ "paw" ] }
 paw = "1.0"
-strum = "0.22.0"
 strum_macros = "0.22.0"
+strum = { version = "0.22", features = ["derive"] }
 comfy-table = "4.1.1"

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -1,68 +1,47 @@
 use avro_rs::{schema_compatibility::SchemaCompatibility, Schema};
 use std::collections::HashMap;
-use std::ffi::OsStr;
-use std::{fmt, panic};
-
-use crate::errors::DegaussError;
+use strum_macros::{Display, EnumIter, EnumString, EnumVariantNames};
 
 ///
 /// Possible compatibility mode array between schemas
 #[derive(
-    strum_macros::EnumIter, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, strum_macros::Display,
+    EnumIter,
+    EnumVariantNames,
+    EnumString,
+    Display,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Debug,
 )]
 pub enum DegaussCompatMode {
     /// Can read the data written by the most recent previous schema.
+    #[strum(serialize = "backwards")]
     Backwards,
+
     /// Can read the data written by all earlier schemas.
+    #[strum(serialize = "backwards-transitive")]
     BackwardsTransitive,
-    /// The data written by this schema can be read by the most recent previous schema.    
+
+    /// The data written by this schema can be read by the most recent previous schema.  
+    #[strum(serialize = "forwards")]
     Forwards,
+
     /// The data written by this schema can be read by all earlier schemas.
+    #[strum(serialize = "forwards-transitive")]
     ForwardsTransitive,
+
     /// Can read the data written by, a write data readable by the most recent previous schema.
+    #[strum(serialize = "full")]
     Full,
+
     /// Can read the data written by, a write data readable by all earlier schemas.
+    #[strum(serialize = "full-transitive")]
     FullTransitive,
-}
-
-impl fmt::Debug for DegaussCompatMode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Backwards => write!(f, "Backwards"),
-            Self::BackwardsTransitive => write!(f, "BackwardsTransitive"),
-            Self::Forwards => write!(f, "Forwards"),
-            Self::ForwardsTransitive => write!(f, "ForwardsTransitive"),
-            Self::Full => write!(f, "Full"),
-            Self::FullTransitive => write!(f, "FullTransitive"),
-        }
-    }
-}
-
-impl TryFrom<&str> for DegaussCompatMode {
-    type Error = DegaussError;
-
-    fn try_from(s: &str) -> Result<Self, Self::Error> {
-        Ok(match s.to_lowercase().as_str() {
-            "backwards" => Self::Backwards,
-            "backwards-transitive" | "backwardstransitive" => Self::BackwardsTransitive,
-            "forwards" => Self::Forwards,
-            "forwards-transitive" | "forwardstransitive" => Self::ForwardsTransitive,
-            "full" => Self::Full,
-            "full-transitive" | "fulltransitive" => Self::FullTransitive,
-            _ => return Err(DegaussError::ParseFailure),
-        })
-    }
-}
-
-impl From<&OsStr> for DegaussCompatMode {
-    fn from(s: &OsStr) -> Self {
-        s.to_owned()
-            .into_string()
-            .unwrap_or_else(|op| panic!("Failed to decode compatibility: {:#?}", op))
-            .as_str()
-            .try_into()
-            .unwrap()
-    }
 }
 
 // /// Also known as 'backwards'. Can read the data written by the most recent previous schema.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,9 +2,6 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum DegaussError {
-    #[error("Parse failure")]
-    ParseFailure,
-
     #[error("File read error")]
     IO(#[from] std::io::Error),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,13 @@ mod errors;
 mod schema;
 mod table;
 
+use crate::compat::DegaussCheck;
 use avro_rs::Schema;
 use compat::DegaussCompatMode;
 use schema::FromFile;
 use std::{panic, path::PathBuf};
 use structopt::StructOpt;
-
-use crate::compat::DegaussCheck;
+use strum::VariantNames;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const AUTHORS: &str = env!("CARGO_PKG_AUTHORS");
@@ -27,7 +27,7 @@ struct Degauss {
     schemas: Vec<PathBuf>,
 
     /// Compat Mode to check against
-    #[structopt(short, long, parse(from_os_str))]
+    #[structopt(short, long,  possible_values = DegaussCompatMode::VARIANTS, case_insensitive = true,)]
     compat: DegaussCompatMode,
 
     /// Print the exit status

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -7,13 +7,13 @@ use std::path::Path;
 /// Parse a given file and convert it to Schema object
 pub trait FromFile {
     /// Parses a given file path into a a valid Schema object
-    fn parse_file(path: &Path) -> Result<Schema, DegaussError>;
+    fn parse_file<P: AsRef<Path>>(path: P) -> Result<Schema, DegaussError>;
 }
 
 /// Implements the FromFile trait for reading Schema from a given file
 impl FromFile for Schema {
     /// Parses a given file into a a valid Schema object
-    fn parse_file(path: &Path) -> Result<Schema, DegaussError> {
+    fn parse_file<P: AsRef<Path>>(path: P) -> Result<Schema, DegaussError> {
         let mut file = File::open(path)?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;

--- a/src/table.rs
+++ b/src/table.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 /// Render the HashMap with its values
 pub(crate) fn render(payload: &HashMap<DegaussCompatMode, bool>) {
     let mut table = Table::new();
-    table.set_header(vec!["CheckType", "Status"]);
+    table.set_header(vec!["Compatibility", "Status"]);
     for (key, value) in payload.iter() {
         table.add_row(vec![key.to_string(), value.to_string()]);
     }

--- a/tests/backward_compat_tests.rs
+++ b/tests/backward_compat_tests.rs
@@ -2,7 +2,6 @@
 /// previous schema.
 #[cfg(test)]
 mod backward_compat {
-    use std::{path::PathBuf, str::FromStr};
 
     use avro_rs::Schema;
     use degauss::prelude::*;
@@ -10,8 +9,8 @@ mod backward_compat {
     #[test]
     fn adding_a_field_with_default_is_a_backward_compatible() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::Backwards);
         assert_eq!(dc.validate(&schemas), true);
@@ -20,8 +19,8 @@ mod backward_compat {
     #[test]
     fn adding_a_field_wo_default_is_not_a_backward_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema3.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema3.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::Backwards);
         assert_eq!(dc.validate(&schemas), false);
@@ -30,8 +29,8 @@ mod backward_compat {
     #[test]
     fn evolving_a_field_type_to_a_union_is_a_backward_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema6.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema6.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::Backwards);
         assert_eq!(dc.validate(&schemas), true);
@@ -40,8 +39,8 @@ mod backward_compat {
     #[test]
     fn removing_a_type_from_a_union_is_not_a_backward_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema6.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema6.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::Backwards);
         assert_eq!(dc.validate(&schemas), false);
@@ -50,8 +49,8 @@ mod backward_compat {
     #[test]
     fn adding_a_new_type_in_union_is_a_backward_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema7.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema6.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema7.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema6.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::Backwards);
         assert_eq!(dc.validate(&schemas), true);
@@ -60,8 +59,8 @@ mod backward_compat {
     #[test]
     fn removing_a_type_from_a_union_is_not_a_backward_compatible_change_second_try() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema6.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema7.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema6.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema7.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::Backwards);
         assert_eq!(dc.validate(&schemas), false);
@@ -70,9 +69,9 @@ mod backward_compat {
     #[test]
     fn removing_a_default_is_not_a_transitively_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema3.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema3.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::BackwardsTransitive);
         assert_eq!(dc.validate(&schemas), true);

--- a/tests/backward_transitive_compat_tests.rs
+++ b/tests/backward_transitive_compat_tests.rs
@@ -2,7 +2,6 @@
 /// in all previous schemas.
 #[cfg(test)]
 mod backward_transitive_compat {
-    use std::{path::PathBuf, str::FromStr};
 
     use avro_rs::Schema;
     use degauss::prelude::*;
@@ -10,9 +9,9 @@ mod backward_transitive_compat {
     #[test]
     fn iteratively_adding_fields_with_defaults_is_a_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema8.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema8.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::BackwardsTransitive);
         assert_eq!(dc.validate(&schemas), true);
@@ -21,8 +20,8 @@ mod backward_transitive_compat {
     #[test]
     fn adding_a_field_with_default_is_a_backward_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::BackwardsTransitive);
         assert_eq!(dc.validate(&schemas), true);
@@ -31,8 +30,8 @@ mod backward_transitive_compat {
     #[test]
     fn removing_a_default_is_a_compatible_change_but_not_transitively() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema3.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema3.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::BackwardsTransitive);
         assert_eq!(dc.validate(&schemas), true);
@@ -41,9 +40,9 @@ mod backward_transitive_compat {
     #[test]
     fn removing_a_default_is_not_a_transitively_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema3.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema3.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::BackwardsTransitive);
         assert_eq!(dc.validate(&schemas), false);

--- a/tests/forward_compat_tests.rs
+++ b/tests/forward_compat_tests.rs
@@ -4,7 +4,6 @@
 /// Forward compatibility: A new schema is forward compatible if the previous schema can read data written in this
 /// schema.
 mod forward_compat {
-    use std::{path::PathBuf, str::FromStr};
 
     use avro_rs::Schema;
     use degauss::prelude::*;
@@ -12,8 +11,8 @@ mod forward_compat {
     #[test]
     fn adding_a_field_is_a_forward_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::Forwards);
         assert_eq!(dc.validate(&schemas), true);
@@ -22,8 +21,8 @@ mod forward_compat {
     #[test]
     fn adding_a_field_is_a_forward_compatible_change_second_try() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema3.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema3.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::Forwards);
         assert_eq!(dc.validate(&schemas), true);
@@ -32,8 +31,8 @@ mod forward_compat {
     #[test]
     fn adding_a_field_is_a_forward_compatible_change_third_try() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema3.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema3.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::Forwards);
         assert_eq!(dc.validate(&schemas), true);
@@ -42,8 +41,8 @@ mod forward_compat {
     #[test]
     fn adding_a_field_is_a_forward_compatible_change_fourth_try() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema3.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema3.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::Forwards);
         assert_eq!(dc.validate(&schemas), true);
@@ -52,9 +51,9 @@ mod forward_compat {
     #[test]
     fn removing_a_default_is_not_a_transitively_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema3.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema3.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::Forwards);
         assert_eq!(dc.validate(&schemas), true);

--- a/tests/forward_transitive_compat_tests.rs
+++ b/tests/forward_transitive_compat_tests.rs
@@ -2,7 +2,6 @@
 /// in this schema.
 #[cfg(test)]
 mod forward_transitive_compat {
-    use std::{path::PathBuf, str::FromStr};
 
     use avro_rs::Schema;
     use degauss::prelude::*;
@@ -10,9 +9,9 @@ mod forward_transitive_compat {
     #[test]
     fn iteratively_removing_fields_with_defaults_is_a_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema8.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema8.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::ForwardsTransitive);
         assert_eq!(dc.validate(&schemas), true);
@@ -21,8 +20,8 @@ mod forward_transitive_compat {
     #[test]
     fn adding_default_to_a_field_is_a_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema3.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema3.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::ForwardsTransitive);
         assert_eq!(dc.validate(&schemas), true);
@@ -31,8 +30,8 @@ mod forward_transitive_compat {
     #[test]
     fn removing_a_field_with_a_default_is_a_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::ForwardsTransitive);
         assert_eq!(dc.validate(&schemas), true);
@@ -41,9 +40,9 @@ mod forward_transitive_compat {
     #[test]
     fn removing_a_default_is_not_a_transitively_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema3.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema3.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::ForwardsTransitive);
         assert_eq!(dc.validate(&schemas), false);

--- a/tests/full_compat_tests.rs
+++ b/tests/full_compat_tests.rs
@@ -1,7 +1,6 @@
 /// Full compatibility: A new schema is fully compatible if it’s both backward and forward compatible.
 #[cfg(test)]
 mod full_compat {
-    use std::{path::PathBuf, str::FromStr};
 
     use avro_rs::Schema;
     use degauss::prelude::*;
@@ -9,8 +8,8 @@ mod full_compat {
     #[test]
     fn adding_a_field_with_default_is_a_backward_and_a_forward_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::Full);
         assert_eq!(dc.validate(&schemas), true);
@@ -19,9 +18,9 @@ mod full_compat {
     #[test]
     fn transitively_adding_a_field_without_a_default_is_not_a_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema3.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema3.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::Full);
         assert_eq!(dc.validate(&schemas), true);
@@ -30,9 +29,9 @@ mod full_compat {
     #[test]
     fn transitively_removing_a_field_without_a_default_is_not_a_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema3.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema3.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::Full);
         assert_eq!(dc.validate(&schemas), true);

--- a/tests/full_transitive_compat_tests.rs
+++ b/tests/full_transitive_compat_tests.rs
@@ -2,7 +2,6 @@
 /// forward compatible with the entire schema history.
 #[cfg(test)]
 mod full_transitive_compat {
-    use std::{path::PathBuf, str::FromStr};
 
     use avro_rs::Schema;
     use degauss::prelude::*;
@@ -10,9 +9,9 @@ mod full_transitive_compat {
     #[test]
     fn iteratively_adding_fields_with_defaults_is_a_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema8.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema8.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::FullTransitive);
         assert_eq!(dc.validate(&schemas), true);
@@ -21,9 +20,9 @@ mod full_transitive_compat {
     #[test]
     fn iteratively_removing_fields_with_defaults_is_a_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema8.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema8.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::FullTransitive);
         assert_eq!(dc.validate(&schemas), true);
@@ -32,8 +31,8 @@ mod full_transitive_compat {
     #[test]
     fn adding_default_to_a_field_is_a_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema3.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema3.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::FullTransitive);
         assert_eq!(dc.validate(&schemas), true);
@@ -42,8 +41,8 @@ mod full_transitive_compat {
     #[test]
     fn removing_a_field_with_a_default_is_a_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::FullTransitive);
         assert_eq!(dc.validate(&schemas), true);
@@ -52,8 +51,8 @@ mod full_transitive_compat {
     #[test]
     fn adding_a_field_with_default_is_a_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::FullTransitive);
         assert_eq!(dc.validate(&schemas), true);
@@ -62,8 +61,8 @@ mod full_transitive_compat {
     #[test]
     fn removing_a_default_from_a_field_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema3.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema3.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::FullTransitive);
         assert_eq!(dc.validate(&schemas), true);
@@ -72,9 +71,9 @@ mod full_transitive_compat {
     #[test]
     fn transitively_adding_a_field_without_a_default_is_not_a_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema3.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema3.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::FullTransitive);
         assert_eq!(dc.validate(&schemas), false);
@@ -83,9 +82,9 @@ mod full_transitive_compat {
     #[test]
     fn transitively_removing_a_field_without_a_default_is_not_a_compatible_change() {
         let schemas = vec![
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema2.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema3.avsc").unwrap()).unwrap(),
-            Schema::parse_file(&PathBuf::from_str("tests/data/schema1.avsc").unwrap()).unwrap(),
+            Schema::parse_file("tests/data/schema2.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema3.avsc").unwrap(),
+            Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
         let dc = DegaussCheck(DegaussCompatMode::FullTransitive);
         assert_eq!(dc.validate(&schemas), false);


### PR DESCRIPTION
- use strum::EnumVariant and strum::serialize to construct `compatibility` values
- Removed unused error enum variants
- Rename table-column from `Checktype` to `Compatibility`
- Schema::parse_file now accepts <P: AsRef<Path>> rather than Pathbuf


Slight improvement in the user-experience, given a wrong compatibility type:
```rust
degauss -s tests/data/movies-raw-reader.avsc tests/data/movies-raw-writer.avsc -c backward --exit-status

error: 'backward' isn't a valid value for '--compat <compat>'
	[possible values: backwards, backwards-transitive, forwards, forwards-transitive, full, full-transitive]

	Did you mean 'backwards'?

```


Rendered table now looks like this:
```
degauss -s tests/data/movies-raw-reader.avsc tests/data/movies-raw-writer.avsc -c backwards --exit-status
+---------------+--------+
| Compatibility | Status |
+========================+
| backwards     | false  |
+---------------+--------+
```