### PR TITLE
scr: Schema Registry Client

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -44,6 +44,10 @@ jobs:
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
+        env:
+          DEGAUSS_SCHEMA_REGISTRY_URL: ${{ secrets.DEGAUSS_SCHEMA_REGISTRY_URL }}
+          DEGAUSS_SCHEMA_REGISTRY_USER: ${{ secrets.DEGAUSS_SCHEMA_REGISTRY_USER }}
+          DEGAUSS_SCHEMA_REGISTRY_PASS: ${{ secrets.DEGAUSS_SCHEMA_REGISTRY_PASS }}
         with:
           command: test
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +80,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "cache-padded"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
+
+[[package]]
+name = "castaway"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed247d1586918e46f2bbe0f13b06498db8dab5a8c1093f156652e9f2e0a73fc3"
+
+[[package]]
+name = "cc"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,12 +137,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
 ]
 
 [[package]]
@@ -136,12 +190,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "curl"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc6d233563261f8db6ffb83bbaad5a73837a6e6b28868e926337ebbdece0be3"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "winapi",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.51+curl-7.80.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d130987e6a6a34fe0889e1083022fa48cd90e6709a84be3fb8dd95801de5af20"
+dependencies = [
+ "cc",
+ "libc",
+ "libnghttp2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "winapi",
+]
+
+[[package]]
 name = "degauss"
 version = "0.1.3"
 dependencies = [
  "avro-rs",
  "comfy-table",
+ "isahc",
  "paw",
+ "serde",
+ "serde_json",
  "structopt",
  "strum 0.22.0",
  "strum_macros 0.22.0",
@@ -155,6 +243,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
+
+[[package]]
+name = "fastrand"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+
+[[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
 ]
 
 [[package]]
@@ -208,12 +363,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "isahc"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d140e84730d325378912ede32d7cd53ef1542725503b3353e5ec8113c7c6f588"
+dependencies = [
+ "async-channel",
+ "castaway",
+ "crossbeam-utils",
+ "curl",
+ "curl-sys",
+ "encoding_rs",
+ "event-listener",
+ "futures-lite",
+ "http",
+ "log",
+ "mime",
+ "once_cell",
+ "polling",
+ "serde",
+ "serde_json",
+ "slab",
+ "sluice",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "waker-fn",
 ]
 
 [[package]]
@@ -255,6 +461,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "libnghttp2-sys"
+version = "0.1.7+1.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ed28aba195b38d5ff02b9170cbff627e336a20925e43b4945390401c5dc93f"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +499,24 @@ checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mio"
@@ -334,6 +580,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df13d165e607909b363a4757a6f133f8a818a74e9d3a98d09c6128e15fa4c73"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +661,57 @@ name = "paw-raw"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f0b59668fe80c5afe998f0c0bf93322bf2cd66cafeeb80581f291716f3467f2"
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pin-project"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
+
+[[package]]
+name = "polling"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685404d509889fade3e86fe3a5803bca2ec09b0c0778d5ada6ec8bf7a8de5259"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "wepoll-ffi",
+ "winapi",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -496,6 +824,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,10 +901,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+
+[[package]]
+name = "sluice"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7400c0eff44aa2fcb5e31a5f24ba9716ed90138769e4977a2ba6014ae63eb5"
+dependencies = [
+ "async-channel",
+ "futures-core",
+ "futures-io",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+
+[[package]]
+name = "socket2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "strsim"
@@ -709,6 +1074,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "tracing"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+dependencies = [
+ "cfg-if",
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "typed-builder"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +1147,21 @@ name = "typenum"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -744,6 +1182,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +1202,12 @@ dependencies = [
  "getrandom 0.2.3",
  "serde",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -766,6 +1222,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,6 +1238,15 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wepoll-ffi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
  "lazy_static",
  "libflate",
  "num-bigint",
- "rand",
+ "rand 0.7.3",
  "serde",
  "serde_json",
  "strum 0.18.0",
@@ -228,6 +228,7 @@ dependencies = [
  "comfy-table",
  "isahc",
  "paw",
+ "rand 0.8.4",
  "serde",
  "serde_json",
  "structopt",
@@ -592,6 +593,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
+name = "openssl-src"
+version = "300.0.2+3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14a760a11390b1a5daf72074d4f6ff1a6e772534ae191f999f57e9ee8146d1fb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +610,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -769,9 +780,21 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.16",
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+ "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -781,7 +804,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -794,12 +827,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom 0.2.3",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core 0.6.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,9 @@ paw = "1.0"
 strum_macros = "0.22.0"
 strum = { version = "0.22", features = ["derive"] }
 comfy-table = "4.1.1"
+isahc = {version = "1.5", features = ["json"]}
+serde_json = "1.0"
+
+[dependencies.serde]
+features = ["derive"]
+version = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,32 +1,35 @@
 [package]
-name = "degauss"
-version = "0.1.3"
-edition = "2021"
 authors = [
-    "Theo B. <vertexclique@gmail.com>",
-    "Ankur S. <asrivas.cs@gmail.com>"
+  "Theo B. <vertexclique@gmail.com>",
+  "Ankur S. <asrivas.cs@gmail.com>",
 ]
-keywords = ["schema-compatibility", "compatibility", "serialization"]
 categories = ["development-tools", "command-line-utilities"]
-homepage = "https://github.com/vertexclique/degauss"
-repository = "https://github.com/vertexclique/degauss"
-documentation = "https://docs.rs/degauss"
-readme = "README.md"
-license = "Apache-2.0/MIT"
 description = "Your friendly neighborhood Avro schema compatibility checker."
+documentation = "https://docs.rs/degauss"
+edition = "2021"
+homepage = "https://github.com/vertexclique/degauss"
+keywords = ["schema-compatibility", "compatibility", "serialization"]
+license = "Apache-2.0/MIT"
+name = "degauss"
+readme = "README.md"
+repository = "https://github.com/vertexclique/degauss"
+version = "0.1.3"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-thiserror = "1.0"
 avro-rs = "0.13"
-structopt = { version = "0.3", features = [ "paw" ] }
-paw = "1.0"
-strum_macros = "0.22.0"
-strum = { version = "0.22", features = ["derive"] }
 comfy-table = "4.1.1"
-isahc = {version = "1.5", features = ["json"]}
+isahc = {version = "1.6", features = ["json", "static-ssl"]}
+paw = "1.0"
 serde_json = "1.0"
+structopt = {version = "0.3", features = ["paw"]}
+strum = {version = "0.22", features = ["derive"]}
+strum_macros = "0.22.0"
+thiserror = "1.0"
 
 [dependencies.serde]
 features = ["derive"]
 version = "1.0"
+
+[dev-dependencies]
+rand = "0.8"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
 
 ## Install
 
+### Grab a release from [releases](https://github.com/vertexclique/degauss/releases)
+
+### Using cargo
 ```
 cargo install degauss
 ```
@@ -23,10 +26,36 @@ cargo install degauss
 
 - Check the compatibility of your schemas
     ```
-    degauss -s tests/data/movies-raw-reader.avsc tests/data/movies-raw-writer.avsc -c full-transitive
+    $ degauss validate -s tests/data/movies-raw-reader.avsc tests/data/movies-raw-writer.avsc -c full-transitive
     ```
 
 - Check the compatibility and set the exit status in case of a failure.
     ```
-    degauss -s tests/data/movies-raw-reader.avsc tests/data/movies-raw-writer.avsc -c full-transitive --exit-status
+    $ degauss validate -s tests/data/movies-raw-reader.avsc tests/data/movies-raw-writer.avsc -c full-transitive --exit-status
+    ```
+
+- Register a schema to schema-registry
+    - create a file with env variables
+    ```        
+    $ cat env
+    export DEGAUSS_SCHEMA_REGISTRY_URL=https://some-url
+    export DEGAUSS_SCHEMA_REGISTRY_USER=some-user
+    export DEGAUSS_SCHEMA_REGISTRY_PASS=some-pass
+    ```
+    ```
+    $ source env
+    ```
+
+    ```
+    $ degauss schema-registry register --subject-type value --topic test2 --schema-path ./tests/data/movies-raw-reader.avsc
+    ```
+
+- Get the compatibility for a subject:
+    ```
+    $ degauss schema-registry compatibility get --subject-type value --topic test
+    ```
+
+- Set the compatibility for a subject:
+    ```
+    $ degauss schema-registry compatibility set --subject-type value --topic test --compatibility forward
     ```

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -91,7 +91,7 @@ pub enum DegaussCompatMode {
 // /** Also known as 'full transitive'. Can read the data written by, a write data readable by all earlier schemas. */
 // MUTUAL_READ_WITH_ALL(ChronologyType.ALL, CheckType.MUTUAL_READ);
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DegaussCheck(pub DegaussCompatMode);
 
 impl DegaussCheck {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,28 @@
+// MIT License
+//
+// Copyright (c) 2021 Theo M. Bulut, Ankur Srivastava
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+//! Errors to be used with the library, converts to and from
+//! other dependencies' errors.
+
 use thiserror::Error;
 
 #[allow(dead_code)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,6 @@
 use thiserror::Error;
 
+#[allow(dead_code)]
 #[derive(Error, Debug)]
 pub enum DegaussError {
     #[error("File read error")]
@@ -7,4 +8,19 @@ pub enum DegaussError {
 
     #[error("Schema parsing error")]
     Schema(#[from] avro_rs::Error),
+
+    #[error("Serializing/Deserializing error")]
+    Serde(#[from] serde_json::Error),
+
+    #[error("HTTP Client error")]
+    HTTPClient(#[from] isahc::Error),
+
+    #[error("HTTP Protocol error")]
+    Http(#[from] isahc::http::Error),
+
+    #[error("Status Code `{error_code}` Message: {message}")]
+    SrHttp { error_code: i32, message: String },
+
+    #[error("{0}")]
+    Custom(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,11 @@ pub mod errors;
 pub mod schema;
 pub mod table;
 
+mod schema_registry;
+pub use schema_registry::{ResponseExt, SchemaRegistryClient, SerdeExt};
 pub mod prelude {
     pub use crate::compat::*;
     pub use crate::errors::*;
     pub use crate::schema::*;
+    pub use crate::schema_registry::types::*;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,87 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(missing_debug_implementations)]
+
+//!
+//!
+//! <div align="center">
+//! <p><h1>DeGauss</h1> </p>
+//! <p><strong>Your friendly neighborhood Avro schema compatibility checker.</strong> </p>
+//! <p>
+//!
+//! [![cicd](https://github.com/vertexclique/degauss/actions/workflows/cicd.yml/badge.svg)](https://github.com/vertexclique/degauss/actions/workflows/cicd.yml)
+//! [![Crates.io](https://img.shields.io/crates/v/degauss)](https://crates.io/crates/degauss)
+//! [![Docs.rs](https://docs.rs/degauss/badge.svg)](https://docs.rs/degauss)
+//! [![codecov](https://codecov.io/gh/vertexclique/degauss/branch/master/graph/badge.svg)](https://codecov.io/gh/vertexclique/degauss)
+//! </p>
+//! </div>
+//! </br>
+//!
+//!
+//! ## Usage
+//!
+//! `degauss` can be used to check the compatibility of schemas and help with schema evolution.
+//!
+//! Let's consider a scenario, we have a schema which is registered on kafka.
+//! ```bash
+//! cat schema_v1.avsc
+//!
+//! {
+//! "type": "record",
+//! "name": "movie",
+//! "fields": [
+//! {
+//!         "name": "movie_id",
+//!         "type": "long"
+//!     },
+//!     {
+//!         "name": "title",
+//!         "type": "string"
+//!     },
+//!     {
+//!         "name": "release_year",
+//!         "type": "long"
+//!     }
+//! ]
+//! }
+//! ```
+//! Another user wants to evolve this schema but wants to make sure if the new schema adheres to the compatibility
+//! guarantees for the given topic. The resulting v2 of this schema could look like:
+//!
+//!```bash
+//! cat schema_v2.avsc
+//!
+//! {
+//! "type": "record",
+//! "name": "movie",
+//! "fields": [
+//! {
+//!         "name": "movie_id",
+//!         "type": "long"
+//!     },
+//!     {
+//!         "name": "title",
+//!         "type": "string"
+//!     }
+//! ]
+//! }
+//! ```
+//!
+//! The person can simply use degauss to check this.
+//! ```bash
+//! degauss -s older_schema.avsc current_schema.avsc --compat forward # or choose from several compatibilities
+//! ```
+
 pub mod compat;
 pub mod errors;
 pub mod schema;
 pub mod table;
 
-mod schema_registry;
-pub use schema_registry::{ResponseExt, SchemaRegistryClient, SerdeExt};
+pub mod schema_registry;
+
 pub mod prelude {
     pub use crate::compat::*;
     pub use crate::errors::*;
     pub use crate::schema::*;
     pub use crate::schema_registry::types::*;
+    pub use crate::schema_registry::*;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
-mod compat;
-mod errors;
-mod schema;
-mod table;
-
-use crate::compat::DegaussCheck;
 use avro_rs::Schema;
-use compat::DegaussCompatMode;
-use schema::FromFile;
+use degauss::compat::{DegaussCheck, DegaussCompatMode};
+use degauss::schema::FromFile;
+use degauss::table;
+use degauss::SerdeExt;
+use degauss::{
+    prelude::{Auth, SchemaSubjectType},
+    SchemaRegistryClient,
+};
 use std::{panic, path::PathBuf};
 use structopt::StructOpt;
 use strum::VariantNames;
@@ -19,59 +19,219 @@ const AUTHORS: &str = env!("CARGO_PKG_AUTHORS");
 /// Kafka schema compatibility checker
 struct Degauss {
     /// Activate debug mode
-    #[structopt(short, long)]
+    #[structopt(short, long, global = true)]
     debug: bool,
 
+    /// Print the exit status
+    #[structopt(short, long, global = true)]
+    exit_status: bool,
+
+    #[structopt(subcommand)]
+    cmd: SubCommand,
+}
+
+#[derive(StructOpt, Debug)]
+/// Options to set during the interaction with compatibility
+struct ValidateOpts {
     /// All schemas in chronological order. From oldest to newest.
     #[structopt(short, long, parse(from_os_str))]
     schemas: Vec<PathBuf>,
 
     /// Compat Mode to check against
-    #[structopt(short, long,  possible_values = DegaussCompatMode::VARIANTS, case_insensitive = true,)]
+    #[structopt(short, long, possible_values = DegaussCompatMode::VARIANTS, case_insensitive = true,)]
     compat: DegaussCompatMode,
-
-    /// Print the exit status
-    #[structopt(short, long)]
-    exit_status: bool,
 }
 
-fn main() {
-    let matches: Degauss = Degauss::from_args();
+#[derive(StructOpt, Debug)]
+enum SRCommand {
+    /// Register a given schema to kafka schema registry
+    Register(RegisterOpts),
 
-    let schemas = matches
-        .schemas
+    /// Set or Get compatibility for a given topic/subject
+    Compatibility(Compatibility),
+}
+
+#[derive(StructOpt, Debug)]
+/// Interact with Kafka Schema Registry
+struct SchemaRegistry {
+    #[structopt(long, env = "DEGAUSS_SCHEMA_REGISTRY_URL")]
+    schema_registry_url: String,
+
+    /// Schema registry username
+    #[structopt(long, env = "DEGAUSS_SCHEMA_REGISTRY_USER")]
+    schema_registry_user: Option<String>,
+
+    /// Schema registry password
+    #[structopt(long, env = "DEGAUSS_SCHEMA_REGISTRY_PASS")]
+    schema_registry_pass: Option<String>,
+
+    #[structopt(subcommand)]
+    cmd: SRCommand,
+}
+
+#[derive(StructOpt, Debug)]
+enum SubCommand {
+    /// Validate the compatibility
+    Validate(ValidateOpts),
+
+    /// Interact with Schema Registry
+    SchemaRegistry(SchemaRegistry),
+}
+
+#[derive(StructOpt, Debug)]
+/// Interact with Kafka Schema Registry
+struct Compatibility {
+    #[structopt(long, env = "DEGAUSS_SCHEMA_REGISTRY_URL")]
+    schema_registry_url: String,
+
+    /// Schema registry username
+    #[structopt(long, env = "DEGAUSS_SCHEMA_REGISTRY_USER")]
+    schema_registry_user: Option<String>,
+
+    /// Schema registry password
+    #[structopt(long, env = "DEGAUSS_SCHEMA_REGISTRY_PASS")]
+    schema_registry_pass: Option<String>,
+
+    #[structopt(subcommand)]
+    cmd: CompatibilityCommand,
+}
+
+#[derive(StructOpt, Debug)]
+/// Interact with Kafka Schema Registry
+enum CompatibilityCommand {
+    /// Get compatibility mode for a given topic/subject on schema registry
+    Get(CompatibilityOpts),
+
+    /// Set compatibility for a given topic/subject on schema registry
+    Set(CompatibilityOpts),
+}
+
+#[derive(StructOpt, Debug)]
+/// Interact with Kafka Schema Registry
+struct RegisterOpts {
+    /// Schema registry username
+    #[structopt(long, env = "DEGAUSS_TOPIC")]
+    topic: String,
+
+    /// Schema registry password
+    #[structopt(long, possible_values = SchemaSubjectType::VARIANTS, env = "DEGAUSS_SUBJECT_TYPE", case_insensitive = true)]
+    subject_type: SchemaSubjectType,
+
+    /// Absolute path to the schema file to register
+    #[structopt(short, long, parse(from_os_str), env = "DEGAUSS_SCHEMA_PATH")]
+    schema_path: PathBuf,
+}
+
+#[derive(StructOpt, Debug)]
+/// Options to set during the interaction with compatibility
+struct CompatibilityOpts {
+    /// Schema registry topic
+    #[structopt(long, env = "DEGAUSS_TOPIC")]
+    topic: String,
+
+    /// Schema registry subject type
+    #[structopt(long, possible_values = SchemaSubjectType::VARIANTS, env = "DEGAUSS_SUBJECT_TYPE", case_insensitive = true)]
+    subject_type: SchemaSubjectType,
+
+    /// Compatibility to set, not needed with Get commands
+    #[structopt(short, long, possible_values = DegaussCompatMode::VARIANTS,env = "DEGAUSS_COMPATIBILITY", case_insensitive = true,)]
+    compatibility: Option<DegaussCompatMode>,
+}
+
+fn validate(schemas: Vec<PathBuf>, compatibility: DegaussCompatMode) -> bool {
+    let schemas = schemas
         .iter()
         .map(|e| Schema::parse_file(e).unwrap_or_else(|op| panic!("Failed to find file {:#?}", op)))
         .collect::<Vec<Schema>>();
 
-    match (schemas.len(), matches.compat) {
+    match (schemas.len(), compatibility) {
         (1, _) => panic!("There is nothing to compare against. Exiting."),
-        (2, DegaussCompatMode::Backwards | DegaussCompatMode::Forwards | DegaussCompatMode::Full) => {
-            let dc = DegaussCheck(matches.compat);
+        (2, DegaussCompatMode::Backward | DegaussCompatMode::Forward | DegaussCompatMode::Full) => {
+            let dc = DegaussCheck(compatibility);
             let compatibility = dc.tabular_validate(&schemas);
             table::render(&compatibility);
-
-            if matches.exit_status {
-                if !compatibility.values().all(|x| *x) {
-                    std::process::exit(1);
-                } else {
-                    std::process::exit(0);
-                }
-            }
+            return compatibility.values().all(|x| *x) ;
         },
-        (sl, DegaussCompatMode::BackwardsTransitive | DegaussCompatMode::ForwardsTransitive | DegaussCompatMode::FullTransitive) if sl >= 2 => {
-            let dc = DegaussCheck(matches.compat);
+        (sl, DegaussCompatMode::BackwardTransitive | DegaussCompatMode::ForwardTransitive | DegaussCompatMode::FullTransitive) if sl >= 2 => {
+            let dc = DegaussCheck(compatibility);
             let compatibility = dc.tabular_validate(&schemas);
             table::render(&compatibility);
+            return compatibility.values().all(|x| *x) ;
+        }
+        (a, e) => panic!("Schema count and compatibility check failure. {} compatibility and {} schemas are not comparable.", e, a)
+    }
+}
 
-            if matches.exit_status {
-                if !compatibility.values().all(|x| *x) {
+fn main() {
+    let degauss_cli: Degauss = Degauss::from_args();
+
+    match degauss_cli.cmd {
+        SubCommand::Validate(opts) => {
+            let valid = validate(opts.schemas, opts.compat);
+            if degauss_cli.exit_status {
+                if !valid {
                     std::process::exit(1);
                 } else {
                     std::process::exit(0);
                 }
             }
         }
-        (a, e) => panic!("Schema count and compatibility check failure. {} compatibility and {} schemas are not comparable.", e, a)
+        SubCommand::SchemaRegistry(sr) => {
+            let auth = match (sr.schema_registry_user, sr.schema_registry_pass) {
+                (Some(user), Some(pass)) => Auth::Basic {
+                    username: user,
+                    password: pass,
+                },
+                (None, None) => Auth::Skip,
+                _ => panic!("Please set both user/pass, not just one"),
+            };
+            let client = SchemaRegistryClient::new(sr.schema_registry_url, auth)
+                .expect("Failed to create a Schema Registry client");
+            match sr.cmd {
+                SRCommand::Compatibility(comp) => match comp.cmd {
+                    CompatibilityCommand::Get(opts) => {
+                        match client.get_compatibility(&opts.topic, opts.subject_type) {
+                            Ok(compat) => println!("{}", compat.pretty_string()),
+                            Err(e) => {
+                                println!("{}", e);
+                                if degauss_cli.exit_status {
+                                    std::process::exit(1);
+                                }
+                            }
+                        }
+                    }
+                    CompatibilityCommand::Set(opts) => {
+                        match client.set_compatibility(
+                            &opts.topic,
+                            opts.subject_type,
+                            opts.compatibility.unwrap(),
+                        ) {
+                            Ok(compat) => println!("{}", compat.pretty_string()),
+                            Err(e) => {
+                                println!("{}", e);
+                                if degauss_cli.exit_status {
+                                    std::process::exit(1);
+                                }
+                            }
+                        }
+                    }
+                },
+                SRCommand::Register(opts) => {
+                    let schema =
+                        Schema::parse_file(opts.schema_path).expect("Schema file not found");
+                    match client.register_schema(&schema, &opts.topic, opts.subject_type) {
+                        Ok(resp) => {
+                            println!("{}", resp.pretty_string());
+                        }
+                        Err(e) => {
+                            println!("{}", e);
+                            if degauss_cli.exit_status {
+                                std::process::exit(1);
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,30 @@
+// MIT License
+//
+// Copyright (c) 2021 Theo M. Bulut, Ankur Srivastava
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 use avro_rs::Schema;
 use degauss::compat::{DegaussCheck, DegaussCompatMode};
+use degauss::prelude::{Auth, SchemaRegistryClient, SchemaSubjectType, SerdeExt};
 use degauss::schema::FromFile;
 use degauss::table;
-use degauss::SerdeExt;
-use degauss::{
-    prelude::{Auth, SchemaSubjectType},
-    SchemaRegistryClient,
-};
 use std::{panic, path::PathBuf};
 use structopt::StructOpt;
 use strum::VariantNames;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,3 +1,14 @@
+//!
+//! Helper traits to assist the Schema object.
+//! This can be used to read a file and convert it to avro_rs::Schema object.
+//!
+//! ```rust,no_run
+//! use avro_rs::Schema;
+//! use degauss::prelude::*;
+//! let schema = Schema::parse_file("path/to/avsc/file").unwrap();
+//! ```
+//!
+
 use crate::errors::*;
 use avro_rs::Schema;
 use std::fs::File;

--- a/src/schema_registry/client.rs
+++ b/src/schema_registry/client.rs
@@ -1,0 +1,294 @@
+// MIT License
+//
+// Copyright (c) 2021 Theo M. Bulut, Ankur Srivastava
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use crate::compat::DegaussCompatMode;
+use crate::errors::DegaussError;
+use crate::schema_registry::types::*;
+
+use crate::schema_registry::ResponseExt;
+use avro_rs::Schema;
+use isahc::{
+    auth::{Authentication, Credentials},
+    config::{RedirectPolicy, VersionNegotiation},
+    prelude::*,
+    HttpClient, Request,
+};
+use serde::Serialize;
+use std::time::Duration;
+
+/// Create an instance of SchemaRegistryClient
+///
+/// ```rust,no_run
+/// use degauss::prelude::*;
+/// use degauss::SchemaRegistryClient;
+///
+/// let client = SchemaRegistryClient::new("http://localhost:8081",
+///         Auth::Basic{
+///         username: "username".to_string(),
+///         password: "password".to_string(),
+///     })
+///     .unwrap();
+/// ```
+pub struct SchemaRegistryClient {
+    httpclient: isahc::HttpClient,
+    url: String,
+}
+
+impl SchemaRegistryClient {
+    fn get_subject_from_topic(&self, topic: &str, subject: SchemaSubjectType) -> String {
+        match subject {
+            SchemaSubjectType::Key => format!("{}-key", topic),
+            SchemaSubjectType::Value => format!("{}-value", topic),
+        }
+    }
+
+    fn make_request<T: ?Sized + Serialize, U: serde::de::DeserializeOwned>(
+        &self,
+        url: &str,
+        method: isahc::http::Method,
+        body: Option<&T>,
+    ) -> Result<U, DegaussError> {
+        let op = match method {
+            isahc::http::Method::PUT => Request::put(url),
+            isahc::http::Method::GET => Request::get(url),
+            isahc::http::Method::POST => Request::post(url),
+            isahc::http::Method::DELETE => Request::delete(url),
+            _ => {
+                return Err(DegaussError::Custom(
+                    "Unsupported method for make_request".to_string(),
+                ));
+            }
+        };
+
+        let b = match body {
+            Some(body) => serde_json::to_vec(body)?,
+            None => vec![],
+        };
+
+        let request = op.body(b)?;
+        let resp = self
+            .httpclient
+            .send(request)?
+            .check_for_error()?
+            .json::<U>()?;
+        Ok(resp)
+    }
+
+    /// Create an instance of the schema registry client
+    ///
+    /// ```rust,no_run
+    /// use degauss::prelude::*;
+    /// use degauss::SchemaRegistryClient;
+    ///
+    /// let client = SchemaRegistryClient::new("http://localhost:8081",
+    ///         Auth::Basic{
+    ///         username: "username".to_string(),
+    ///         password: "password".to_string(),
+    ///     })
+    ///     .unwrap();
+    /// ```
+    pub fn new<T: Into<String>>(url: T, auth: Auth) -> Result<Self, DegaussError> {
+        let builder = HttpClient::builder()
+            .version_negotiation(VersionNegotiation::http11())
+            .redirect_policy(RedirectPolicy::Limit(10))
+            .timeout(Duration::from_secs(20))
+            .default_header("Content-Type", "application/vnd.schemaregistry.v1+json");
+
+        let httpclient = match auth {
+            Auth::Basic { username, password } => builder
+                .authentication(Authentication::basic())
+                .credentials(Credentials::new(username, password)),
+            Auth::Skip => builder,
+        }
+        .build()?;
+        Ok(SchemaRegistryClient {
+            httpclient,
+            url: url.into(),
+        })
+    }
+
+    /// Register the given schema to schema-registry
+    pub fn register_schema(
+        self,
+        schema: &Schema,
+        topic: &str,
+        subject_type: SchemaSubjectType,
+    ) -> Result<SchemaRegistrationResponse, DegaussError> {
+        let url = format!(
+            "{url}/subjects/{subject}/versions",
+            url = self.url,
+            subject = self.get_subject_from_topic(topic, subject_type),
+        );
+
+        let payload = serde_json::json!({ "schema": schema.canonical_form()});
+        let resp = self.make_request(&url, isahc::http::Method::POST, Some(&payload))?;
+        Ok(resp)
+    }
+
+    /// Set the compatibility of a given subject.
+    /// Subject is evaluated using the topic name and the type of subject.
+    ///
+    /// subject = topic-key or topic-value
+    pub fn set_compatibility(
+        self,
+        topic: &str,
+        subject_type: SchemaSubjectType,
+        compatibility: DegaussCompatMode,
+    ) -> Result<SubjectCompatibilitySetResponse, DegaussError> {
+        let url = format!(
+            "{url}/config/{subject}",
+            url = self.url,
+            subject = self.get_subject_from_topic(topic, subject_type),
+        );
+
+        let payload = serde_json::json!({
+            "compatibility": compatibility.to_string()
+        });
+
+        let resp = self.make_request(&url, isahc::http::Method::PUT, Some(&payload))?;
+        Ok(resp)
+    }
+
+    /// Get the compatibility of a given subject.
+    /// Subject is evaluated using the topic name and the type of subject.
+    ///
+    /// subject = topic-key or topic-value
+    pub fn get_compatibility(
+        self,
+        topic: &str,
+        subject_type: SchemaSubjectType,
+    ) -> Result<SubjectCompatibilityGetResponse, DegaussError> {
+        let url = format!(
+            "{url}/config/{subject}",
+            url = self.url,
+            subject = self.get_subject_from_topic(topic, subject_type),
+        );
+
+        let none: Option<String> = None;
+        let resp = self.make_request(&url, isahc::http::Method::GET, none.as_ref())?;
+        Ok(resp)
+    }
+
+    /// Check the compatibility with given Schema
+    pub fn check_compatibility(
+        self,
+        schema: &Schema,
+        topic: &str,
+        subject_type: SchemaSubjectType,
+        verbose: bool,
+    ) -> Result<SchemaCompatibleResponse, DegaussError> {
+        let url = format!(
+            "{url}/compatibility/subjects/{subject}/versions?verbose={verbose}",
+            url = self.url,
+            subject = self.get_subject_from_topic(topic, subject_type),
+            verbose = verbose,
+        );
+        let payload = serde_json::json!({"schema": schema.canonical_form()});
+        let resp = self.make_request(&url, isahc::http::Method::POST, Some(&payload))?;
+        Ok(resp)
+    }
+}
+
+/// previous schema.
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::prelude::FromFile;
+    use avro_rs::Schema;
+
+    fn test_client() -> SchemaRegistryClient {
+        use std::env;
+        let username = env::var("DEGAUSS_SCHEMA_REGISTRY_USER").unwrap();
+        let password = env::var("DEGAUSS_SCHEMA_REGISTRY_PASS").unwrap();
+        let url = env::var("DEGAUSS_SCHEMA_REGISTRY_URL").unwrap();
+
+        SchemaRegistryClient::new(
+            url,
+            Auth::Basic {
+                username: username,
+                password: password,
+            },
+        )
+        .unwrap()
+    }
+
+    fn test_schema() -> Schema {
+        Schema::parse_file("tests/data/schema2.avsc").unwrap()
+    }
+
+    #[test]
+    fn test_register_schema() {
+        let client = test_client();
+        let topic = "test";
+        let schema = test_schema();
+        let res = client
+            .register_schema(&schema, topic, SchemaSubjectType::Value)
+            .unwrap();
+        assert!(res.id > 0)
+    }
+
+    #[test]
+    fn test_set_schema() {
+        let client = test_client();
+        let topic = "test";
+        let res = client
+            .set_compatibility(topic, SchemaSubjectType::Value, DegaussCompatMode::Forward)
+            .unwrap();
+        assert!(res.compatibility == DegaussCompatMode::Forward.to_string());
+    }
+
+    #[test]
+    fn test_get_schema() {
+        let client = test_client();
+        let topic = "test";
+        let res = client
+            .get_compatibility(topic, SchemaSubjectType::Value)
+            .unwrap();
+
+        let want = DegaussCompatMode::Forward;
+        assert!(
+            res.compatibility_level == want,
+            "got {} want {}",
+            res.compatibility_level,
+            want
+        )
+    }
+
+    #[test]
+    fn test_check_compatibility() {
+        let client = test_client();
+        let topic = "test";
+        let schema = test_schema();
+        let res = client
+            .check_compatibility(&schema, topic, SchemaSubjectType::Value, true)
+            .unwrap();
+
+        let want = true;
+        assert!(
+            res.is_compatible == want,
+            "got {} want {}",
+            res.is_compatible,
+            want
+        )
+    }
+}

--- a/src/schema_registry/mod.rs
+++ b/src/schema_registry/mod.rs
@@ -20,6 +20,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+//!
+//! A lightweight schema registry client to interact with Kafka Schema Registry.
+//!
+//! ### Usage
+//! ```rust, no_run
+//! use degauss::prelude::*;
+//! // if username/password is provided
+//! let auth = Auth::Basic {
+//!  username: "user".to_string(),
+//!  password: "pass".to_string(),
+//! };
+//!
+//! // if no username/password then
+//! // let auth = Auth::Skip;
+//! let client = SchemaRegistryClient::new("http://url-of-schema-registry", auth).expect("Failed to create a Schema Registry client");
+//! // Use your client to interact with schema registry
+//!```
+//!
 mod client;
 pub use client::SchemaRegistryClient;
 mod response_ext;

--- a/src/schema_registry/mod.rs
+++ b/src/schema_registry/mod.rs
@@ -1,0 +1,29 @@
+// MIT License
+//
+// Copyright (c) 2021 Theo M. Bulut, Ankur Srivastava
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+mod client;
+pub use client::SchemaRegistryClient;
+mod response_ext;
+pub mod types;
+pub use response_ext::ResponseExt;
+mod serde_ext;
+pub use serde_ext::SerdeExt;

--- a/src/schema_registry/response_ext.rs
+++ b/src/schema_registry/response_ext.rs
@@ -1,0 +1,54 @@
+// MIT License
+//
+// Copyright (c) 2021 Theo M. Bulut, Ankur Srivastava
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use crate::errors::DegaussError;
+use crate::schema_registry::types::*;
+
+use isahc::{prelude::*, Body, Response};
+
+pub trait ResponseExt {
+    fn check_for_error(self) -> Result<Response<Body>, DegaussError>;
+}
+
+/// Implements the FromFile trait for reading Schema from a given file
+impl ResponseExt for Response<Body> {
+    /// Check for error in the incoming response
+    ///
+    /// In case the status is not successful, parse the errors and return the
+    /// corresponding error code
+    ///
+    /// ```json
+    /// { error_code: i32, message: String }
+    /// ```
+    fn check_for_error(mut self) -> Result<Response<Body>, DegaussError> {
+        match self.status().is_success() {
+            true => Ok(Response::new(self.into_body())),
+            false => {
+                let err_response = self.json::<SchemaRegistryErrResponse>()?;
+                Err(DegaussError::SrHttp {
+                    error_code: err_response.error_code,
+                    message: err_response.message,
+                })
+            }
+        }
+    }
+}

--- a/src/schema_registry/response_ext.rs
+++ b/src/schema_registry/response_ext.rs
@@ -20,18 +20,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+//! Trait to check for errors from Schema Registry and convert it to
+//! a struct. This is helpful in deserializing the schema registry errors.
+//!
+//! In case the status is not successful, parse the errors and return the
+//! corresponding error code
+//! ```json
+//! { error_code: i32, message: String }
+//! ```
+
 use crate::errors::DegaussError;
 use crate::schema_registry::types::*;
 
 use isahc::{prelude::*, Body, Response};
 
+/// ResponseExt trait for checking errors in the incoming response
+/// from Kafka Schema Registry
 pub trait ResponseExt {
-    fn check_for_error(self) -> Result<Response<Body>, DegaussError>;
-}
-
-/// Implements the FromFile trait for reading Schema from a given file
-impl ResponseExt for Response<Body> {
-    /// Check for error in the incoming response
+    /// Check for error in the incoming response from Kafka Schema Registry
     ///
     /// In case the status is not successful, parse the errors and return the
     /// corresponding error code
@@ -39,6 +45,10 @@ impl ResponseExt for Response<Body> {
     /// ```json
     /// { error_code: i32, message: String }
     /// ```
+    fn check_for_error(self) -> Result<Response<Body>, DegaussError>;
+}
+
+impl ResponseExt for Response<Body> {
     fn check_for_error(mut self) -> Result<Response<Body>, DegaussError> {
         match self.status().is_success() {
             true => Ok(Response::new(self.into_body())),

--- a/src/schema_registry/serde_ext.rs
+++ b/src/schema_registry/serde_ext.rs
@@ -1,0 +1,16 @@
+use serde::Serialize;
+
+pub trait SerdeExt {
+    fn pretty_string(&self) -> String;
+}
+
+impl<T> SerdeExt for T
+where
+    T: ?Sized + Serialize,
+{
+    /// Converts a serializable struct to pretty json
+    /// Fails in case the serde fails to convert it to pretty string.
+    fn pretty_string(&self) -> String {
+        serde_json::to_string(self).unwrap()
+    }
+}

--- a/src/schema_registry/serde_ext.rs
+++ b/src/schema_registry/serde_ext.rs
@@ -1,6 +1,45 @@
+// MIT License
+//
+// Copyright (c) 2021 Theo M. Bulut, Ankur Srivastava
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 use serde::Serialize;
 
+/// SerdeExt trait to convert any Serializable struct to
+/// json string.
 pub trait SerdeExt {
+    /// Converts a serializable struct to pretty json
+    /// Fails in case the serde fails to convert it to pretty string.
+    ///
+    /// ```rust, no_run
+    /// use serde::Serialize;
+    /// use degauss::prelude::*;
+    ///
+    /// #[derive(Serialize)]
+    /// pub struct Test{
+    ///   pub name: String
+    /// }
+    ///
+    /// let test = Test{name:"degauss".to_string()};
+    /// println!("{}", test.pretty_string());
+    ///
     fn pretty_string(&self) -> String;
 }
 
@@ -8,8 +47,6 @@ impl<T> SerdeExt for T
 where
     T: ?Sized + Serialize,
 {
-    /// Converts a serializable struct to pretty json
-    /// Fails in case the serde fails to convert it to pretty string.
     fn pretty_string(&self) -> String {
         serde_json::to_string(self).unwrap()
     }

--- a/src/schema_registry/types.rs
+++ b/src/schema_registry/types.rs
@@ -22,6 +22,7 @@ use crate::compat::DegaussCompatMode;
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#[derive(Debug)]
 pub enum Auth {
     Basic { username: String, password: String },
     Skip,

--- a/src/schema_registry/types.rs
+++ b/src/schema_registry/types.rs
@@ -1,0 +1,77 @@
+use crate::compat::DegaussCompatMode;
+
+// MIT License
+//
+// Copyright (c) 2021 Theo M. Bulut, Ankur Srivastava
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+pub enum Auth {
+    Basic { username: String, password: String },
+    Skip,
+}
+use strum_macros::{Display, EnumIter, EnumString, EnumVariantNames};
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct SchemaRegistryErrResponse {
+    pub error_code: i32,
+    pub message: String,
+}
+
+/// The subject for this we are going to register a schema
+#[derive(
+    EnumIter,
+    EnumVariantNames,
+    EnumString,
+    Display,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Debug,
+)]
+pub enum SchemaSubjectType {
+    #[strum(serialize = "key")]
+    Key,
+    #[strum(serialize = "value")]
+    Value,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct SchemaRegistrationResponse {
+    pub id: i32,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct SchemaCompatibleResponse {
+    pub is_compatible: bool,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct SubjectCompatibilitySetResponse {
+    pub compatibility: String,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct SubjectCompatibilityGetResponse {
+    #[serde(rename(serialize = "compatibilityLevel", deserialize = "compatibilityLevel"))]
+    pub compatibility_level: DegaussCompatMode,
+}

--- a/src/table.rs
+++ b/src/table.rs
@@ -4,7 +4,7 @@ use comfy_table::Table;
 use std::collections::HashMap;
 
 /// Render the HashMap with its values
-pub(crate) fn render(payload: &HashMap<DegaussCompatMode, bool>) {
+pub fn render(payload: &HashMap<DegaussCompatMode, bool>) {
     let mut table = Table::new();
     table.set_header(vec!["Compatibility", "Status"]);
     for (key, value) in payload.iter() {

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,9 +1,40 @@
+// MIT License
+//
+// Copyright (c) 2021 Theo M. Bulut, Ankur Srivastava
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 #![allow(dead_code)]
 use crate::compat::DegaussCompatMode;
 use comfy_table::Table;
 use std::collections::HashMap;
 
-/// Render the HashMap with its values
+/// Render the HashMap with its values, in tabular format
+///
+///```bash
+/// }+---------------+--------+
+/// | Compatibility | Status |
+/// +========================+
+/// | forward       | true   |
+/// +---------------+--------+
+///```
+///
 pub fn render(payload: &HashMap<DegaussCompatMode, bool>) {
     let mut table = Table::new();
     table.set_header(vec!["Compatibility", "Status"]);

--- a/tests/backward_compat_tests.rs
+++ b/tests/backward_compat_tests.rs
@@ -12,7 +12,7 @@ mod backward_compat {
             Schema::parse_file("tests/data/schema2.avsc").unwrap(),
             Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
-        let dc = DegaussCheck(DegaussCompatMode::Backwards);
+        let dc = DegaussCheck(DegaussCompatMode::Backward);
         assert_eq!(dc.validate(&schemas), true);
     }
 
@@ -22,7 +22,7 @@ mod backward_compat {
             Schema::parse_file("tests/data/schema3.avsc").unwrap(),
             Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
-        let dc = DegaussCheck(DegaussCompatMode::Backwards);
+        let dc = DegaussCheck(DegaussCompatMode::Backward);
         assert_eq!(dc.validate(&schemas), false);
     }
 
@@ -32,7 +32,7 @@ mod backward_compat {
             Schema::parse_file("tests/data/schema6.avsc").unwrap(),
             Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
-        let dc = DegaussCheck(DegaussCompatMode::Backwards);
+        let dc = DegaussCheck(DegaussCompatMode::Backward);
         assert_eq!(dc.validate(&schemas), true);
     }
 
@@ -42,7 +42,7 @@ mod backward_compat {
             Schema::parse_file("tests/data/schema1.avsc").unwrap(),
             Schema::parse_file("tests/data/schema6.avsc").unwrap(),
         ];
-        let dc = DegaussCheck(DegaussCompatMode::Backwards);
+        let dc = DegaussCheck(DegaussCompatMode::Backward);
         assert_eq!(dc.validate(&schemas), false);
     }
 
@@ -52,7 +52,7 @@ mod backward_compat {
             Schema::parse_file("tests/data/schema7.avsc").unwrap(),
             Schema::parse_file("tests/data/schema6.avsc").unwrap(),
         ];
-        let dc = DegaussCheck(DegaussCompatMode::Backwards);
+        let dc = DegaussCheck(DegaussCompatMode::Backward);
         assert_eq!(dc.validate(&schemas), true);
     }
 
@@ -62,7 +62,7 @@ mod backward_compat {
             Schema::parse_file("tests/data/schema6.avsc").unwrap(),
             Schema::parse_file("tests/data/schema7.avsc").unwrap(),
         ];
-        let dc = DegaussCheck(DegaussCompatMode::Backwards);
+        let dc = DegaussCheck(DegaussCompatMode::Backward);
         assert_eq!(dc.validate(&schemas), false);
     }
 
@@ -73,7 +73,7 @@ mod backward_compat {
             Schema::parse_file("tests/data/schema2.avsc").unwrap(),
             Schema::parse_file("tests/data/schema3.avsc").unwrap(),
         ];
-        let dc = DegaussCheck(DegaussCompatMode::BackwardsTransitive);
+        let dc = DegaussCheck(DegaussCompatMode::BackwardTransitive);
         assert_eq!(dc.validate(&schemas), true);
     }
 }

--- a/tests/backward_transitive_compat_tests.rs
+++ b/tests/backward_transitive_compat_tests.rs
@@ -13,7 +13,7 @@ mod backward_transitive_compat {
             Schema::parse_file("tests/data/schema2.avsc").unwrap(),
             Schema::parse_file("tests/data/schema8.avsc").unwrap(),
         ];
-        let dc = DegaussCheck(DegaussCompatMode::BackwardsTransitive);
+        let dc = DegaussCheck(DegaussCompatMode::BackwardTransitive);
         assert_eq!(dc.validate(&schemas), true);
     }
 
@@ -23,7 +23,7 @@ mod backward_transitive_compat {
             Schema::parse_file("tests/data/schema2.avsc").unwrap(),
             Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
-        let dc = DegaussCheck(DegaussCompatMode::BackwardsTransitive);
+        let dc = DegaussCheck(DegaussCompatMode::BackwardTransitive);
         assert_eq!(dc.validate(&schemas), true);
     }
 
@@ -33,7 +33,7 @@ mod backward_transitive_compat {
             Schema::parse_file("tests/data/schema3.avsc").unwrap(),
             Schema::parse_file("tests/data/schema2.avsc").unwrap(),
         ];
-        let dc = DegaussCheck(DegaussCompatMode::BackwardsTransitive);
+        let dc = DegaussCheck(DegaussCompatMode::BackwardTransitive);
         assert_eq!(dc.validate(&schemas), true);
     }
 
@@ -44,7 +44,7 @@ mod backward_transitive_compat {
             Schema::parse_file("tests/data/schema1.avsc").unwrap(),
             Schema::parse_file("tests/data/schema3.avsc").unwrap(),
         ];
-        let dc = DegaussCheck(DegaussCompatMode::BackwardsTransitive);
+        let dc = DegaussCheck(DegaussCompatMode::BackwardTransitive);
         assert_eq!(dc.validate(&schemas), false);
     }
 }

--- a/tests/forward_compat_tests.rs
+++ b/tests/forward_compat_tests.rs
@@ -14,7 +14,7 @@ mod forward_compat {
             Schema::parse_file("tests/data/schema2.avsc").unwrap(),
             Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
-        let dc = DegaussCheck(DegaussCompatMode::Forwards);
+        let dc = DegaussCheck(DegaussCompatMode::Forward);
         assert_eq!(dc.validate(&schemas), true);
     }
 
@@ -24,7 +24,7 @@ mod forward_compat {
             Schema::parse_file("tests/data/schema3.avsc").unwrap(),
             Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
-        let dc = DegaussCheck(DegaussCompatMode::Forwards);
+        let dc = DegaussCheck(DegaussCompatMode::Forward);
         assert_eq!(dc.validate(&schemas), true);
     }
 
@@ -34,7 +34,7 @@ mod forward_compat {
             Schema::parse_file("tests/data/schema3.avsc").unwrap(),
             Schema::parse_file("tests/data/schema2.avsc").unwrap(),
         ];
-        let dc = DegaussCheck(DegaussCompatMode::Forwards);
+        let dc = DegaussCheck(DegaussCompatMode::Forward);
         assert_eq!(dc.validate(&schemas), true);
     }
 
@@ -44,7 +44,7 @@ mod forward_compat {
             Schema::parse_file("tests/data/schema2.avsc").unwrap(),
             Schema::parse_file("tests/data/schema3.avsc").unwrap(),
         ];
-        let dc = DegaussCheck(DegaussCompatMode::Forwards);
+        let dc = DegaussCheck(DegaussCompatMode::Forward);
         assert_eq!(dc.validate(&schemas), true);
     }
 
@@ -55,7 +55,7 @@ mod forward_compat {
             Schema::parse_file("tests/data/schema2.avsc").unwrap(),
             Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
-        let dc = DegaussCheck(DegaussCompatMode::Forwards);
+        let dc = DegaussCheck(DegaussCompatMode::Forward);
         assert_eq!(dc.validate(&schemas), true);
     }
 }

--- a/tests/forward_transitive_compat_tests.rs
+++ b/tests/forward_transitive_compat_tests.rs
@@ -13,7 +13,7 @@ mod forward_transitive_compat {
             Schema::parse_file("tests/data/schema2.avsc").unwrap(),
             Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
-        let dc = DegaussCheck(DegaussCompatMode::ForwardsTransitive);
+        let dc = DegaussCheck(DegaussCompatMode::ForwardTransitive);
         assert_eq!(dc.validate(&schemas), true);
     }
 
@@ -23,7 +23,7 @@ mod forward_transitive_compat {
             Schema::parse_file("tests/data/schema2.avsc").unwrap(),
             Schema::parse_file("tests/data/schema3.avsc").unwrap(),
         ];
-        let dc = DegaussCheck(DegaussCompatMode::ForwardsTransitive);
+        let dc = DegaussCheck(DegaussCompatMode::ForwardTransitive);
         assert_eq!(dc.validate(&schemas), true);
     }
 
@@ -33,7 +33,7 @@ mod forward_transitive_compat {
             Schema::parse_file("tests/data/schema2.avsc").unwrap(),
             Schema::parse_file("tests/data/schema1.avsc").unwrap(),
         ];
-        let dc = DegaussCheck(DegaussCompatMode::ForwardsTransitive);
+        let dc = DegaussCheck(DegaussCompatMode::ForwardTransitive);
         assert_eq!(dc.validate(&schemas), true);
     }
 
@@ -44,7 +44,7 @@ mod forward_transitive_compat {
             Schema::parse_file("tests/data/schema3.avsc").unwrap(),
             Schema::parse_file("tests/data/schema2.avsc").unwrap(),
         ];
-        let dc = DegaussCheck(DegaussCompatMode::ForwardsTransitive);
+        let dc = DegaussCheck(DegaussCompatMode::ForwardTransitive);
         assert_eq!(dc.validate(&schemas), false);
     }
 }


### PR DESCRIPTION

Split the application into two subcommands:
```
SUBCOMMANDS:
    help               Prints this message or the help of the given subcommand(s)
    schema-registry    Interact with Schema Registry
    validate           Validate the compatibility
```
Implemented initial version of SchemaRegistryClient interaction
- Create an instance of the client from the URL and Basic Auth
- Register the provided Schema object to a topic for a given key i.e. key/value
  - subject will become topic-key/topic-value
- Get compatibility associated with a given subject
  - subject will be fetched as topic-key/topic-value

- Check compatibility with a given Schema
- implemented the cli on top of it, check README.md